### PR TITLE
Add g:instant_markdown_browser variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ let g:instant_markdown_autostart = 0
 
 in your .vimrc. You can then manually trigger preview via the command ```:InstantMarkdownPreview```. This command is only available inside markdown buffers and when the autostart option is turned off.
 
+### g:instant_markdown_browser
+By default, vim-install-markdown will use the default browser. If you want to
+use an another browser, you can specify
+
+```
+let g:instant_markdown_browser = "google-chrome"
+```
+
 Supported Platforms
 -------------------
 OSX and Unix/Linuxes*.

--- a/after/ftplugin/markdown/instant-markdown.vim
+++ b/after/ftplugin/markdown/instant-markdown.vim
@@ -24,7 +24,11 @@ function! s:refreshView()
 endfu
 
 function! s:startDaemon(initialMD)
-    call s:system("instant-markdown-d &>/dev/null &", a:initialMD)
+    if exists('g:instant_markdown_browser')
+        call s:system("instant-markdown-d --browser=" . g:instant_markdown_browser . " &>/dev/null &", a:initialMD)
+    else
+        call s:system("instant-markdown-d &>/dev/null &", a:initialMD)
+    endif
 endfu
 
 function! s:initDict()


### PR DESCRIPTION
It allows to use `g:instant_markdown_browser` variable e.g.:

```
let g:instant_markdown_browser = "google-chrome"
let g:instant_markdown_browser = "firefox"
```

But it requires https://github.com/suan/instant-markdown-d/pull/24
