### PR TITLE
inject cursor marker to output for window position syncing

### DIFF
--- a/after/ftplugin/markdown/instant-markdown.vim
+++ b/after/ftplugin/markdown/instant-markdown.vim
@@ -48,7 +48,13 @@ function! s:killDaemon()
 endfu
 
 function! s:bufGetContents(bufnr)
-  return join(getbufline(a:bufnr, 1, "$"), "\n")
+  let lines = getbufline(a:bufnr, 1, "$")
+
+  " inject row marker
+  let row_num = line(".") - 1
+  let lines[row_num] = join([lines[row_num], '<a name="#marker" id="marker"></a>'], ' ')
+
+  return join(lines, "\n")
 endfu
 
 " I really, really hope there's a better way to do this.


### PR DESCRIPTION
This commit will place an invisible anchor to the output that maps to the cursor position of the markdown document. It allows the ability to sync scroll position in the HTML document.

Dependent on https://github.com/suan/instant-markdown-d/pull/26
Resolves https://github.com/suan/vim-instant-markdown/issues/46
