### PR TITLE
allow buffers to switch to hidden without losing preview

### DIFF
--- a/after/ftplugin/markdown/instant-markdown.vim
+++ b/after/ftplugin/markdown/instant-markdown.vim
@@ -108,7 +108,7 @@ fu! s:previewMarkdown()
     else
       au CursorHold,CursorHoldI,CursorMoved,CursorMovedI <buffer> call s:temperedRefresh()
     endif
-    au BufWinLeave <buffer> call s:cleanUp()
+    au BufUnload <buffer> call s:cleanUp()
   aug END
 endfu
 
@@ -127,7 +127,7 @@ if g:instant_markdown_autostart
         else
           au CursorHold,CursorHoldI,CursorMoved,CursorMovedI <buffer> call s:temperedRefresh()
         endif
-        au BufWinLeave <buffer> call s:popMarkdown()
+        au BufUnload <buffer> call s:popMarkdown()
         au BufwinEnter <buffer> call s:pushMarkdown()
     aug END
 else


### PR DESCRIPTION
Sometimes I need to switch to edit another buffer `:e newfile` and then go back to my markdown buffer. This commit will correctly restore the preview even after you have switched to another buffer (in the same window) and then coming back to your markdown file.
