### PR TITLE
expand(<bufnr>) don't work

### DIFF
--- a/after/ftplugin/markdown/instant-markdown.vim
+++ b/after/ftplugin/markdown/instant-markdown.vim
@@ -18,7 +18,7 @@ function! s:system(cmd, stdin)
 endfu
 
 function! s:refreshView()
-    let bufnr = expand('<bufnr>')
+    let bufnr = s:myBufNr()
     call s:system("curl -X PUT -T - http://localhost:8090/ &>/dev/null &",
                 \ s:bufGetContents(bufnr))
 endfu


### PR DESCRIPTION
I use s:myBufNr() instead.
It works fine before I change My .vimrc
After move to https://github.com/spf13/spf13-vim,it can't work.
With the help of vim usr doc, it runs well now.
Is it true?