### PR TITLE
(Temporarily) enable logging of server and curl for troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ To block such content, edit your .vimrc and add
 let g:instant_markdown_allow_external_content = 0
 ```
 
+### g:instant_markdown_logfile
+For troubleshooting, server startup and curl communication from Vim to the server can be logged into a file.
+
+```
+let g:instant_markdown_logfile = '/tmp/instant_markdown.log'
+```
+
 Supported Platforms
 -------------------
 OSX, Unix/Linuxes*, and Windows**.

--- a/after/ftplugin/markdown/instant-markdown.vim
+++ b/after/ftplugin/markdown/instant-markdown.vim
@@ -19,6 +19,10 @@ if !exists('g:instant_markdown_allow_external_content')
     let g:instant_markdown_allow_external_content = 1
 endif
 
+if !exists('g:instant_markdown_logfile')
+    let g:instant_markdown_logfile = (has('win32') || has('win64') ? 'NUL' : '/dev/null')
+endif
+
 " # Utility Functions
 " Simple system wrapper that ignores empty second args
 function! s:system(cmd, stdin)
@@ -36,7 +40,7 @@ function! s:systemasync(cmd, stdinLines)
     if has('win32') || has('win64')
         call s:winasync(a:cmd, a:stdinLines)
     else
-        let cmd = a:cmd . '&>/dev/null &'
+        let cmd = a:cmd . '&>>' . g:instant_markdown_logfile . ' &'
         call s:system(cmd, join(a:stdinLines, "\n"))
     endif
 endfu
@@ -56,7 +60,7 @@ function! s:winasync(cmd, stdinLines)
     else
         let command = a:cmd
     endif
-    exec 'silent !start /b cmd /c ' . command . ' > NUL'
+    exec 'silent !start /b cmd /c ' . command . ' >> ' . g:instant_markdown_logfile
 endfu
 
 function! s:refreshView()


### PR DESCRIPTION
I first had issues with curl, because inside GVIM, the `$no_proxy` variable wasn't set somehow, and curl attempted to contact the localhost URL via the proxy, which obviously doesn't work.
Extract a new `g:instant_markdown_logfile` configuration that defaults to the (platform-specific) _null device_, and append (`>>` instead of overwriting via `>`). If troubleshooting is needed, the config can be set to a log filespec.