### PR TITLE
Prepend env variables while calling instant-markdown-d

### DIFF
--- a/after/ftplugin/markdown/instant-markdown.vim
+++ b/after/ftplugin/markdown/instant-markdown.vim
@@ -85,12 +85,12 @@ function! s:startDaemon(initialMDLines)
         let env .= 'INSTANT_MARKDOWN_BLOCK_EXTERNAL=1 '
     endif
     if g:instant_markdown_mathjax
-        let s:imd_argv = ' --mathjax'
+        let s:argv = ' --mathjax'
     else
-        let s:imd_argv = ''
+        let s:argv = ''
     endif
 
-    call s:systemasync('instant-markdown-d'.s:imd_argv, a:initialMDLines)
+    call s:systemasync(env.'instant-markdown-d'.s:argv, a:initialMDLines)
 endfu
 
 function! s:initDict()


### PR DESCRIPTION
Fixes #130, replaces #129.