### PR TITLE
Verbose exit

### DIFF
--- a/after/ftplugin/markdown/instant-markdown.vim
+++ b/after/ftplugin/markdown/instant-markdown.vim
@@ -131,7 +131,7 @@ function! s:popBuffer(bufnr)
 endfu
 
 function! s:killDaemon()
-    call s:systemasync("curl -s -X DELETE http://localhost:".g:instant_markdown_port, [])
+    call s:systemasync("curl -X DELETE -w 'exit status: %{http_code}' http://localhost:".g:instant_markdown_port, [])
 endfu
 
 function! s:bufGetLines(bufnr)


### PR DESCRIPTION
Previously the silent flag was used for curl. This will allow to debug suan/instant-markdown-d/issues/63

cc: @xdandyx, can you update the vim plugin and see what the log shows.
