### PR TITLE
Make browser arguments function correctly

### DIFF
--- a/after/ftplugin/markdown/instant-markdown.vim
+++ b/after/ftplugin/markdown/instant-markdown.vim
@@ -113,7 +113,7 @@ function! s:startDaemon(initialMDLines)
         endif
     endif
     if exists('g:instant_markdown_browser')
-        let argv .= ' --browser '.g:instant_markdown_browser
+        let argv .= " --browser '".g:instant_markdown_browser."'"
     endif
     let argv .= ' --port '.g:instant_markdown_port
 


### PR DESCRIPTION
To make browser arguments function correctly, for example
```vim
let g:instant_markdown_browser = "firefox --new-window"
```
the whole browser command should be wrapped with single quotes, then the following command will be executed.
```sh                                                                             
instant-markdown-d --browser 'firefox --new-window'
```
Otherwise
```sh                                                                             
instant-markdown-d --browser firefox --new-window
```
will be executed. The argument "--new-window" will be passed as the argument of `instant-markdown-d` instead of `firefox`.

(Only tested on Linux)